### PR TITLE
Add Docker build and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM grafana/grafana:4.3.1
+
+ARG NODEJS_SETUP_SCRIPT_URL=https://deb.nodesource.com/setup_6.x
+ARG YARN_KEY_URL=https://dl.yarnpkg.com/debian/pubkey.gpg
+ARG OPENNMS_HELM_GIT_URL=https://github.com/OpenNMS/grafana-opennms-helm-app.git
+ARG OPENNMS_HELM_GIT_BRANCH_REF="master"
+ARG OPENNMS_HELM_APP_DIR=opennms-helm-app
+ENV GF_PATHS_PLUGINS /opt/grafana/plugins
+ENV OPENNMS_HELM_HOME=${GF_PATHS_PLUGINS}/${OPENNMS_HELM_APP_DIR}
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install apt-transport-https && \
+    curl -sS ${YARN_KEY_URL} | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    curl -sL ${NODEJS_SETUP_SCRIPT_URL} | bash - && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install git-core \
+                                       yarn \
+                                       nodejs && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone ${OPENNMS_HELM_GIT_URL} ${OPENNMS_HELM_HOME} && \
+    cd ${OPENNMS_HELM_HOME} && \
+    git checkout ${OPENNMS_HELM_GIT_BRANCH_REF} && \
+    git describe --all > git.describe && \
+    yarn && \
+    yarn build
+
+HEALTHCHECK --interval=10s --timeout=3s CMD curl --fail -s -I http://localhost:3000/login | grep "HTTP/1.1 200 OK" || exit 1
+
+VOLUME ["/opt/grafana/plugins", "/var/lib/grafana", "/var/log/grafana", "/etc/grafana"]
+
+EXPOSE 3000
+
+LABEL maintainer="ronny@opennms.org" \
+      grafana.version="4.3.1" \
+      opennms.helm.git.url=${OPENNMS_HELM_GIT_URL} \
+      opennms.helm.git.branch.ref=${OPENNMS_HELM_GIT_BRANCH_REF} \
+      opennms.helm.license=MIT \
+      opennms.helm.home=${OPENNMS_HELM_HOME}
+
+ENTRYPOINT ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,46 @@ systemctl restart grafana-server
 ```
 
 Enable the plugin by navigating to `Plugins`, `Apps` and then selecting `OpenNMS Helm`.
+
+### Build with Docker
+
+The source can be compiled from source with a Docker builder image.
+
+```
+docker build -t myopennmshelmimage .
+```
+
+will checkout the source from GitHub URL of the project, compile and installs the plugin.
+The result is a runnable image which can be executed with
+
+```
+docker run -p 3000:3000 -t myopennmshelmimage
+```
+
+Login on http://your-ip:3000 with login admin:admin and go to Plugins and enable the Helm app.
+
+IMPORTANT: The plugin directory location is changed from `/var/lib/grafana/plugins` to `/opt/grafana/plugins` because the base grafana image defines the `/var/lib/grafana` as a _VOLUME_ which can be changed.
+
+### Advanced Docker build
+
+If you want to build an image based on a specific GitHub fork or branch you can use `--build-arg`:
+
+```
+docker build -t mycustomforkbranch \
+            --build-arg OPENNMS_HELM_GIT_URL=https://github.com/OpenNMS/grafana-opennms-helm-app.git \
+            --build-arg OPENNMS_HELM_GIT_BRANCH_REF=myBranch
+```
+
+This will create a the plugin from the given GitHub URL and branch.
+
+### Use Docker compose to build a service stack
+
+There is an example `docker-compose.yml` which builds a whole service stack with a compiled _Grafana OpenNMS Helm App_ which can be tested.
+
+Modify the build arguments in the `docker-compose.yml` if you want to build from a GitHub fork, branch or version tag.
+
+With first running `docker-compose up -d` the _Grafana OpenNMS Helm App_ will be compiled from source.
+Any run will use the compiled image from on the local system.
+If you want to rebuild the image run `docker-compose build --no-cache` to rebuild the image with the build configuration in the given `docker-compose.yml`.
+
+The URL for the data source in Grafana for the OpenNMS Horizon server is `http://opennms:8980/rest`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '2'
+volumes:
+  data-postgres:
+    driver: "local"
+  data-opennms:
+    driver: "local"
+  data-opennms-helm:
+    driver: "local"
+networks:
+  onms-net:
+    driver: bridge
+services:
+  database:
+    image: postgres:9.6.1
+    container_name: opennms-postgresql
+    environment:
+      - TZ=Europe/Berlin
+      - POSTGRES_HOST=database
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - data-postgres:/var/lib/postgresql/data
+    networks:
+      - onms-net
+  opennms:
+    image: opennms/horizon-core-web:19.1.0-1
+    container_name: opennms-horizon-core-web
+    cap_add:
+      - NET_ADMIN
+    environment:
+      - TZ=Europe/Berlin
+      - OPENNMS_DBNAME=opennms
+      - OPENNMS_DBUSER=opennms
+      - OPENNMS_DBPASS=opennms
+      - OPENNMS_HOME=/opt/opennms
+      - OPENNMS_DB_CONFIG=/opt/opennms/etc/opennms-datasources.xml
+      - POSTGRES_HOST=database
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    depends_on:
+      - database
+    volumes:
+      - data-opennms:/opennms-data
+    networks:
+      - onms-net
+    command: ["-s"]
+    ports:
+      - "8980:8980"
+      - "18980:18980"
+      - "1099:1099"
+      - "8101:8101"
+      - "61616:61616"
+      - "5817:5817"
+      - "162:162/udp"
+  opennms-helm:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      args:
+        OPENNMS_HELM_GIT_URL: https://github.com/OpenNMS/grafana-opennms-helm-app.git
+        OPENNMS_HELM_GIT_BRANCH_REF: master
+    image: opennms-helm:master
+    volumes:
+      - data-opennms-helm:/var/lib/grafana
+      - data-opennms-helm:/var/log/grafana
+      - data-opennms-helm:/etc/grafana
+    networks:
+      - onms-net
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
Build the Grafana OpenNMS Helm App with Docker based on the official Grafana image. Allow user to specify a GitHub URL and a branch reference for the build. Added documentation and created a sample docker-compose file to build a whole service stack using exisiting PostgreSQL and OpenNMS Horizon images.